### PR TITLE
Fix for Snap package on Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
         "jquery": "^3.4.1",
         "opencollective": "^1.0.3",
         "semver": "^6.2.0",
-        "typeface-roboto": "0.0.54",
-        "electron": "=4.2.6"
+        "typeface-roboto": "0.0.54"
     },
     "devDependencies": {
+        "electron": "=4.2.6",
         "fs-extra": "^8.1.0",
         "jsdom": "^15.1.1",
         "angular-mocks": "^1.7.8",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,14 @@
             "category": "Office",
             "icon": "src/electron/images/",
             "target": [
-                "AppImage"
+                "AppImage",
+                "snap"
             ]
+        },
+        "snap": {
+          "environment": {
+            "DISABLE_WAYLAND": 1
+          }
         }
     },
     "collective": {


### PR DESCRIPTION
I'm unsure about the move of electron from dependencies to devDependencies, but I could not build/test the snap package without it. So if you have some other mechanism that needs it the other way around, just change it back.