### PR TITLE
Add snap setting XDG_DATA_HOME

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
         },
         "snap": {
             "environment": {
-                "DISABLE_WAYLAND": 1
+                "DISABLE_WAYLAND": 1,
+                "XDG_DATA_HOME": "$SNAP_USER_DATA/.local/share"
             }
         }
     }


### PR DESCRIPTION
Fixing `[9493:0724/022521.338143:ERROR:mime_util_xdg.cc(119)] Failed reading in mime.cache file: $HOME/.local/share/flatpak/exports/share/mime/mime.cache`
